### PR TITLE
Implement leaderboard locking for ranking calculation

### DIFF
--- a/game_api/src/http/player_finished.rs
+++ b/game_api/src/http/player_finished.rs
@@ -1,6 +1,7 @@
 use crate::{RecordsErrorKind, RecordsResult, RecordsResultExt};
 use actix_web::web::Json;
 use futures::TryStreamExt;
+use itertools::Itertools;
 use records_lib::{
     event::OptEvent,
     models, player,
@@ -78,13 +79,9 @@ async fn send_query(
     .fetch_one(&mut *db)
     .await?;
 
-    let cps_times = body
-        .cps
-        .iter()
-        .enumerate()
-        .map(|(i, t)| format!("({i}, {map_id}, {record_id}, {t})"))
-        .collect::<Vec<String>>()
-        .join(", ");
+    let cps_times = body.cps.iter().enumerate().format_with(", ", |(i, t), f| {
+        f(&format_args!("({i}, {map_id}, {record_id}, {t})"))
+    });
 
     sqlx::query(
         format!(

--- a/records_lib/src/update_ranks.rs
+++ b/records_lib/src/update_ranks.rs
@@ -48,10 +48,7 @@
 //! But if we don't already know his time, then we can't tell if the returned rank from Redis
 //! is valid or not.
 //!
-//! This is why we have 2 functions to get the rank of a player:
-//! * [`get_rank_opt`], which expects the player ID, and returns an optional rank.
-//! * [`get_rank`], which expects the player ID *and* his real time (retrieved in advance
-//!   from MariaDB), and returns a non-optional rank.
+//! This is why the [`get_rank`] function requires the time of the player.
 
 use crate::{
     error::{RecordsError, RecordsResult},
@@ -273,27 +270,6 @@ async fn get_rank_impl(
         }
     })
     .await
-}
-
-/// Gets the rank of a player in a map, or None if not found.
-///
-/// The ranking type is the standard competition ranking (1224).
-///
-/// See the [module documentation](super) for more information about the ranking system.
-pub async fn get_rank_opt(
-    redis_conn: &mut RedisConnection,
-    map_id: u32,
-    player_id: u32,
-    event: OptEvent<'_, '_>,
-) -> RecordsResult<Option<i32>> {
-    let key = map_key(map_id, event);
-
-    // Get the score (time) of the player
-    let Some(score): Option<i32> = redis_conn.zscore(&key, player_id).await? else {
-        return Ok(None);
-    };
-
-    get_rank_impl(redis_conn, map_id, &key, score).await
 }
 
 /// Gets the rank of a player in a map, or fully updates its leaderboard if not found.

--- a/records_lib/src/update_ranks.rs
+++ b/records_lib/src/update_ranks.rs
@@ -321,6 +321,10 @@ pub async fn get_rank(
             force_update(map_id, event, db).await?;
         }
 
+        // There are cases where the time saved in MariaDB is different from the `time` argument.
+        // Thus, we need to get the time from Redis again, because it's the correct one at this point.
+        let time = db.redis_conn.zscore(&key, player_id).await?;
+
         match get_rank_impl(&mut db.redis_conn, &key, time).await? {
             Some(r) => Ok(r),
             None => Err(get_rank_failed(db, player_id, time, event, map_id).await?),

--- a/records_lib/src/update_ranks.rs
+++ b/records_lib/src/update_ranks.rs
@@ -323,7 +323,7 @@ pub async fn get_rank(
 
         match get_rank_impl(&mut db.redis_conn, &key, time).await? {
             Some(r) => Ok(r),
-            None => Err(get_rank_failed(db, player_id, event, map_id).await?),
+            None => Err(get_rank_failed(db, player_id, time, event, map_id).await?),
         }
     })
     .await
@@ -336,6 +336,7 @@ pub async fn get_rank(
 async fn get_rank_failed(
     db: &mut DatabaseConnection,
     player_id: u32,
+    time: i32,
     event: OptEvent<'_, '_>,
     map_id: u32,
 ) -> RecordsResult<RecordsError> {
@@ -429,7 +430,7 @@ async fn get_rank_failed(
         }
     }
 
-    tracing::error!("missing player rank ({player_id} on {map_id})\n{msg}");
+    tracing::error!("missing player rank ({player_id} on map {map_id} with time {time})\n{msg}");
 
     Ok(RecordsError::Internal)
 }


### PR DESCRIPTION
This PR adds a lock system of a leaderboard when calculating the ranks.

It attempts to fix #27, by minimizing the probability of having a desynchronization between the Redis and the MariaDB leaderboards.