### PR TITLE
Detect false requests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,3 +30,4 @@ once_cell = "1.18.0"
 csv = "1.3.0"
 mkenv = "0.1.6"
 records-lib = { version = "0.1", path = "./records_lib" }
+nom = "8.0.0"

--- a/game_api/Cargo.toml
+++ b/game_api/Cargo.toml
@@ -12,8 +12,8 @@ name = "game_api_lib"
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 async-graphql = { workspace = true, features = [
-  "dataloader",
-  "apollo_tracing",
+    "dataloader",
+    "apollo_tracing",
 ] }
 sqlx = { workspace = true }
 chrono = { workspace = true }
@@ -38,10 +38,12 @@ itertools = { workspace = true }
 once_cell = { workspace = true }
 records-lib = { workspace = true, features = ["tracing"] }
 mkenv = { workspace = true }
+nom = { workspace = true }
 
 [dev-dependencies]
 tracing-test = "0.2.5"
 
 [features]
-default = []
+default = ["request_filter"]
 gql_schema = []
+request_filter = []

--- a/game_api/src/auth.rs
+++ b/game_api/src/auth.rs
@@ -48,10 +48,6 @@
 //! See <https://github.com/maniaplanet/documentation/blob/master/13.web-services/01.oauth2/docs.md#auth-code-flow-or-explicit-flow-or-server-side-flow>
 //! for more information.
 
-use std::future::{ready, Ready};
-use std::pin::Pin;
-use std::{collections::HashMap, time::Duration};
-
 use actix_web::dev::Payload;
 use actix_web::{FromRequest, HttpRequest};
 use chrono::{DateTime, Utc};
@@ -63,6 +59,9 @@ use records_lib::redis_key::{mp_token_key, web_token_key};
 use records_lib::{acquire, Database};
 use serde::{Deserialize, Serialize};
 use sha256::digest;
+use std::future::{ready, Ready};
+use std::pin::Pin;
+use std::{collections::HashMap, time::Duration};
 use tokio::sync::oneshot::{self, Receiver, Sender};
 use tokio::sync::Mutex;
 use tokio::time::timeout;

--- a/game_api/src/env.rs
+++ b/game_api/src/env.rs
@@ -32,6 +32,7 @@ const DEFAULT_MP_CLIENT_ID: &str = "";
 const DEFAULT_MP_CLIENT_SECRET: &str = "";
 const DEFAULT_WH_REPORT_URL: &str = "";
 const DEFAULT_WH_AC_URL: &str = "";
+const DEFAULT_WH_INVALID_REQ_URL: &str = "";
 const DEFAULT_GQL_ENDPOINT: &str = "/graphql";
 
 mkenv::make_env! {pub ApiEnv includes [
@@ -109,6 +110,14 @@ mkenv::make_env! {pub ApiEnv includes [
         var: "WEBHOOK_AC_URL",
         desc: "The URL to the Discord webhook used to share in-game statistics",
         default: DEFAULT_WH_AC_URL,
+    },
+
+    wh_invalid_req_url: {
+        id: WebhookInvalidReqUrl(String),
+        kind: normal,
+        var: "WEBHOOK_INVALID_REQ_URL",
+        desc: "The URL to the Discord webhook used to flag invalid requests",
+        default: DEFAULT_WH_INVALID_REQ_URL,
     },
 
     gql_endpoint: {

--- a/game_api/src/lib.rs
+++ b/game_api/src/lib.rs
@@ -5,6 +5,9 @@
 pub use deadpool_redis::Pool as RedisPool;
 pub use sqlx::MySqlPool;
 
+#[cfg(feature = "request_filter")]
+mod request_filter;
+
 mod auth;
 mod discord_webhook;
 mod env;

--- a/game_api/src/request_filter/check.rs
+++ b/game_api/src/request_filter/check.rs
@@ -46,35 +46,54 @@ pub(crate) async fn flag_invalid_req(
     head: RequestHead,
     connection_info: ConnectionInfo,
 ) -> Result<(), actix_web::Error> {
-    let fields = vec![
-        WebhookBodyEmbedField {
-            name: "Request head".to_owned(),
-            value: format!("```{}```", super::FormattedRequestHead { head: &head }),
-            inline: None,
-        },
-        WebhookBodyEmbedField {
-            name: "Connection info".to_owned(),
-            value: format!(
-                "```{}```",
-                super::FormattedConnectionInfo {
-                    connection_info: &connection_info
-                }
-            ),
-            inline: None,
-        },
-    ];
-
     client
         .post(&crate::env().wh_invalid_req_url)
         .json(&WebhookBody {
             content: "Got an invalid request 🥷".to_owned(),
-            embeds: vec![WebhookBodyEmbed {
-                title: "Info".to_owned(),
-                description: None,
-                color: 5814783,
-                fields: Some(fields),
-                url: None,
-            }],
+            embeds: vec![
+                WebhookBodyEmbed {
+                    title: "Request".to_owned(),
+                    description: None,
+                    color: 5814783,
+                    fields: Some(vec![WebhookBodyEmbedField {
+                        name: "Head".to_owned(),
+                        value: format!("```{}```", super::FormattedRequestHead { head: &head }),
+                        inline: None,
+                    }]),
+                    url: None,
+                },
+                WebhookBodyEmbed {
+                    title: "Connection info".to_owned(),
+                    description: None,
+                    color: 5814783,
+                    fields: Some(vec![
+                        WebhookBodyEmbedField {
+                            name: "Host".to_owned(),
+                            value: connection_info.host().to_owned(),
+                            inline: None,
+                        },
+                        WebhookBodyEmbedField {
+                            name: "Peer address".to_owned(),
+                            value: connection_info.peer_addr().unwrap_or("Unknown").to_owned(),
+                            inline: None,
+                        },
+                        WebhookBodyEmbedField {
+                            name: "Real IP remote address".to_owned(),
+                            value: connection_info
+                                .realip_remote_addr()
+                                .unwrap_or("Unknown")
+                                .to_owned(),
+                            inline: None,
+                        },
+                        WebhookBodyEmbedField {
+                            name: "Scheme".to_owned(),
+                            value: connection_info.scheme().to_owned(),
+                            inline: None,
+                        },
+                    ]),
+                    url: None,
+                },
+            ],
         })
         .send()
         .await

--- a/game_api/src/request_filter/check.rs
+++ b/game_api/src/request_filter/check.rs
@@ -3,7 +3,7 @@
 use actix_web::{
     dev::{ConnectionInfo, RequestHead, ServiceRequest},
     error::InternalError,
-    http::StatusCode,
+    http::{header, StatusCode},
 };
 
 use crate::discord_webhook::{WebhookBody, WebhookBodyEmbed, WebhookBodyEmbedField};
@@ -89,10 +89,8 @@ pub(crate) async fn flag_invalid_req(
 }
 
 pub(crate) fn is_request_valid(req: &ServiceRequest) -> bool {
-    req.headers().get("Authorization").is_some()
-        && req
-            .headers()
-            .get("User-Agent")
-            .filter(|value| is_known_agent(value.as_bytes()))
-            .is_some()
+    req.headers()
+        .get(header::USER_AGENT)
+        .filter(|value| is_known_agent(value.as_bytes()))
+        .is_some()
 }

--- a/game_api/src/request_filter/check.rs
+++ b/game_api/src/request_filter/check.rs
@@ -1,0 +1,98 @@
+//! Module which provides some functions to check if a request is valid or not, and to notify such case.
+
+use actix_web::{
+    dev::{ConnectionInfo, RequestHead, ServiceRequest},
+    error::InternalError,
+    http::StatusCode,
+};
+
+use crate::discord_webhook::{WebhookBody, WebhookBodyEmbed, WebhookBodyEmbedField};
+
+fn is_known_agent(value: &[u8]) -> bool {
+    let Ok((_, parsed)) = super::parse_agent(value) else {
+        return false;
+    };
+
+    match parsed.client {
+        b"Win64" | b"Win32" | b"Linux" => (),
+        _ => return false,
+    }
+
+    match parsed.maniaplanet_version {
+        // Please let me know when Nadeo releases a new version of ManiaPlanet... :(
+        (..3, ..) | (3, ..3, _) | (3, 3, 0) => (),
+        _ => return false,
+    }
+
+    match parsed.rv {
+        (..2019, ..)
+        | (2019, ..11, ..)
+        | (2019, 11, ..19, ..)
+        | (2019, 11, 19, ..18, _)
+        | (2019, 11, 19, 18, ..=50) => (),
+        _ => return false,
+    }
+
+    match parsed.context {
+        b"none" => (),
+        _ => return false,
+    }
+
+    true
+}
+
+pub(crate) async fn flag_invalid_req(
+    client: reqwest::Client,
+    head: RequestHead,
+    connection_info: ConnectionInfo,
+) -> Result<(), actix_web::Error> {
+    let fields = vec![
+        WebhookBodyEmbedField {
+            name: "Request head".to_owned(),
+            value: format!("```{}```", super::FormattedRequestHead { head: &head }),
+            inline: None,
+        },
+        WebhookBodyEmbedField {
+            name: "Connection info".to_owned(),
+            value: format!(
+                "```{}```",
+                super::FormattedConnectionInfo {
+                    connection_info: &connection_info
+                }
+            ),
+            inline: None,
+        },
+    ];
+
+    client
+        .post(&crate::env().wh_invalid_req_url)
+        .json(&WebhookBody {
+            content: "Got an invalid request 🥷".to_owned(),
+            embeds: vec![WebhookBodyEmbed {
+                title: "Info".to_owned(),
+                description: None,
+                color: 5814783,
+                fields: Some(fields),
+                url: None,
+            }],
+        })
+        .send()
+        .await
+        .map_err(|e| {
+            actix_web::Error::from(InternalError::new(
+                format!("Unknown error: {e}"),
+                StatusCode::INTERNAL_SERVER_ERROR,
+            ))
+        })?;
+
+    Ok(())
+}
+
+pub(crate) fn is_request_valid(req: &ServiceRequest) -> bool {
+    req.headers().get("Authorization").is_some()
+        && req
+            .headers()
+            .get("User-Agent")
+            .filter(|value| is_known_agent(value.as_bytes()))
+            .is_some()
+}

--- a/game_api/src/request_filter/format.rs
+++ b/game_api/src/request_filter/format.rs
@@ -1,6 +1,6 @@
 use core::fmt;
 
-use actix_web::dev::{ConnectionInfo, RequestHead};
+use actix_web::dev::RequestHead;
 
 pub(super) struct FormattedHeaderValue<'a> {
     inner: Result<&'a str, &'a [u8]>,
@@ -63,29 +63,6 @@ impl fmt::Display for FormattedRequestHead<'_> {
 
             writeln!(f, "{name}: {value}")?;
         }
-
-        Ok(())
-    }
-}
-
-pub(super) struct FormattedConnectionInfo<'a> {
-    pub(super) connection_info: &'a ConnectionInfo,
-}
-
-impl fmt::Display for FormattedConnectionInfo<'_> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        writeln!(f, "Host: {}", self.connection_info.host())?;
-        writeln!(
-            f,
-            "Peer address: {}",
-            self.connection_info.peer_addr().unwrap_or("None"),
-        )?;
-        writeln!(
-            f,
-            "Real IP remote address: {}",
-            self.connection_info.realip_remote_addr().unwrap_or("None"),
-        )?;
-        writeln!(f, "Scheme: {}", self.connection_info.scheme())?;
 
         Ok(())
     }

--- a/game_api/src/request_filter/format.rs
+++ b/game_api/src/request_filter/format.rs
@@ -1,0 +1,98 @@
+use core::fmt;
+
+use actix_web::dev::{ConnectionInfo, RequestHead};
+
+pub(super) struct FormattedHeaderValue<'a> {
+    inner: Result<&'a str, &'a [u8]>,
+}
+
+impl<'a> FormattedHeaderValue<'a> {
+    pub(super) fn new(val: &'a [u8]) -> Self {
+        Self {
+            inner: std::str::from_utf8(val).map_err(|_| val),
+        }
+    }
+}
+
+impl fmt::Display for FormattedHeaderValue<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        struct List<'a> {
+            inner: &'a [u8],
+        }
+
+        impl fmt::Display for List<'_> {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                let mut list = f.debug_list();
+                list.entries(&self.inner[..self.inner.len().min(100)]);
+                if self.inner.len() > 100 {
+                    list.finish_non_exhaustive()
+                } else {
+                    list.finish()
+                }
+            }
+        }
+
+        match &self.inner {
+            Ok(s) => f.write_str(s),
+            Err(b) => write!(f, "Invalid UTF-8: {}", List { inner: b }),
+        }
+    }
+}
+
+pub(super) struct FormattedRequestHead<'a> {
+    pub(super) head: &'a RequestHead,
+}
+
+impl fmt::Display for FormattedRequestHead<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(
+            f,
+            "{method} {uri} {version:?}",
+            method = self.head.method,
+            uri = self.head.uri,
+            version = self.head.version,
+        )?;
+
+        for (name, value) in self.head.headers.iter() {
+            let value = if name == "Authorization" {
+                b"***"
+            } else {
+                value.as_bytes()
+            };
+            let value = FormattedHeaderValue::new(value);
+
+            writeln!(f, "{name}: {value}")?;
+        }
+
+        Ok(())
+    }
+}
+
+pub(super) struct FormattedConnectionInfo<'a> {
+    pub(super) connection_info: &'a ConnectionInfo,
+}
+
+impl fmt::Display for FormattedConnectionInfo<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "Host: {}", self.connection_info.host())?;
+        writeln!(
+            f,
+            "Peer address: {}",
+            match self.connection_info.peer_addr() {
+                Some(s) => s,
+                None => "None",
+            }
+        )?;
+        writeln!(
+            f,
+            "Real IP remote address: {}",
+            match self.connection_info.realip_remote_addr() {
+                Some(s) => s,
+                None => "None",
+            }
+        )?;
+        writeln!(f, "Scheme: {}", self.connection_info.scheme())?;
+
+        Ok(())
+    }
+}

--- a/game_api/src/request_filter/format.rs
+++ b/game_api/src/request_filter/format.rs
@@ -78,18 +78,12 @@ impl fmt::Display for FormattedConnectionInfo<'_> {
         writeln!(
             f,
             "Peer address: {}",
-            match self.connection_info.peer_addr() {
-                Some(s) => s,
-                None => "None",
-            }
+            self.connection_info.peer_addr().unwrap_or("None"),
         )?;
         writeln!(
             f,
             "Real IP remote address: {}",
-            match self.connection_info.realip_remote_addr() {
-                Some(s) => s,
-                None => "None",
-            }
+            self.connection_info.realip_remote_addr().unwrap_or("None"),
         )?;
         writeln!(f, "Scheme: {}", self.connection_info.scheme())?;
 

--- a/game_api/src/request_filter/mod.rs
+++ b/game_api/src/request_filter/mod.rs
@@ -3,7 +3,7 @@ mod format;
 mod parse;
 
 // Used accross the sub-modules
-use format::{FormattedConnectionInfo, FormattedRequestHead};
+use format::FormattedRequestHead;
 use parse::parse_agent;
 
 pub(crate) use check::{flag_invalid_req, is_request_valid};

--- a/game_api/src/request_filter/mod.rs
+++ b/game_api/src/request_filter/mod.rs
@@ -1,0 +1,9 @@
+mod check;
+mod format;
+mod parse;
+
+// Used accross the sub-modules
+use format::{FormattedConnectionInfo, FormattedRequestHead};
+use parse::parse_agent;
+
+pub(crate) use check::{flag_invalid_req, is_request_valid};

--- a/game_api/src/request_filter/parse.rs
+++ b/game_api/src/request_filter/parse.rs
@@ -1,7 +1,7 @@
 use std::str::FromStr;
 
 use nom::{
-    bytes::{tag, take_until, take_while1},
+    bytes::complete::{tag, take_until, take_while1},
     combinator::map_res,
     Parser as _,
 };
@@ -52,10 +52,10 @@ pub(super) fn parse_agent(input: &[u8]) -> nom::IResult<&[u8], ParsedAgent> {
     )
         .parse(input)?;
     let (input, (_, client)) = (tag(" ("), take_until(";")).parse(input)?;
-    let (input, (_, rv)) = (tag(" rv: "), take_until(";")).parse(input)?;
+    let (input, (_, rv)) = (tag("; rv: "), take_until(";")).parse(input)?;
     let (_, rv) = parse_rv(rv)?;
-    let (input, (_, context)) = (tag(" context: "), take_until(";")).parse(input)?;
-    let (input, (_, distro)) = (tag(" distro: "), take_until(";")).parse(input)?;
+    let (input, (_, context)) = (tag("; context: "), take_until(";")).parse(input)?;
+    let (input, (_, distro)) = (tag("; distro: "), take_until(")")).parse(input)?;
 
     Ok((
         input,

--- a/game_api/src/request_filter/parse.rs
+++ b/game_api/src/request_filter/parse.rs
@@ -1,0 +1,70 @@
+use std::str::FromStr;
+
+use nom::{
+    bytes::{tag, take_until, take_while1},
+    combinator::map_res,
+    Parser as _,
+};
+
+pub(super) struct ParsedAgent<'a> {
+    pub(super) maniaplanet_version: (u8, u8, u8),
+    pub(super) rv: (u16, u8, u8, u8, u8),
+    pub(super) client: &'a [u8],
+    pub(super) context: &'a [u8],
+    pub(super) _distro: &'a [u8],
+}
+
+fn parse_unsigned<T: FromStr>(input: &[u8]) -> nom::IResult<&[u8], T> {
+    map_res(
+        take_while1(|c: u8| c.is_ascii_digit()),
+        |input| match std::str::from_utf8(input) {
+            Ok(s) => s.parse().map_err(|_| ()),
+            Err(_) => Err(()),
+        },
+    )
+    .parse(input)
+}
+
+fn parse_rv(input: &[u8]) -> nom::IResult<&[u8], (u16, u8, u8, u8, u8)> {
+    let (input, (a, _, b, _, c, _, d, _, e)) = (
+        parse_unsigned,
+        tag("-"),
+        parse_unsigned,
+        tag("-"),
+        parse_unsigned,
+        tag("_"),
+        parse_unsigned,
+        tag("_"),
+        parse_unsigned,
+    )
+        .parse(input)?;
+    Ok((input, (a, b, c, d, e)))
+}
+
+pub(super) fn parse_agent(input: &[u8]) -> nom::IResult<&[u8], ParsedAgent> {
+    let (input, _) = tag("ManiaPlanet/").parse(input)?;
+    let (input, (major, _, minor, _, patch)) = (
+        parse_unsigned,
+        tag("."),
+        parse_unsigned,
+        tag("."),
+        parse_unsigned,
+    )
+        .parse(input)?;
+    let (input, (_, client)) = (tag(" ("), take_until(";")).parse(input)?;
+    let (input, (_, rv)) = (tag(" rv: "), take_until(";")).parse(input)?;
+    let (_, rv) = parse_rv(rv)?;
+    let (input, (_, context)) = (tag(" context: "), take_until(";")).parse(input)?;
+    let (input, (_, distro)) = (tag(" distro: "), take_until(";")).parse(input)?;
+
+    Ok((
+        input,
+        ParsedAgent {
+            maniaplanet_version: (major, minor, patch),
+            rv,
+            client,
+            context,
+            _distro: distro,
+        },
+    ))
+}

--- a/records_lib/Cargo.toml
+++ b/records_lib/Cargo.toml
@@ -20,7 +20,7 @@ reqwest = { workspace = true }
 futures = { workspace = true }
 tokio = { workspace = true }
 itertools = { workspace = true }
-nom = "7.1.3"
+nom = { workspace = true }
 
 [features]
 default = []

--- a/records_lib/src/modeversion.rs
+++ b/records_lib/src/modeversion.rs
@@ -3,7 +3,7 @@ use std::{fmt, str::FromStr};
 use nom::{
     bytes::complete::{tag, take_while1},
     combinator::{map, map_res},
-    sequence::tuple,
+    Parser as _,
 };
 
 /// The error emitted by the parse of the [`ModeVersion`] type.
@@ -37,18 +37,20 @@ impl fmt::Debug for ModeVersion {
 fn parse_u8(input: &str) -> nom::IResult<&str, u8> {
     map_res(take_while1(|c: char| c.is_ascii_digit()), |input: &str| {
         input.parse()
-    })(input)
+    })
+    .parse(input)
 }
 
 fn parse_mode_version(input: &str) -> nom::IResult<&str, ModeVersion> {
     map(
-        tuple((parse_u8, tag("."), parse_u8, tag("."), parse_u8)),
+        (parse_u8, tag("."), parse_u8, tag("."), parse_u8),
         |(major, _, minor, _, patch)| ModeVersion {
             major,
             minor,
             patch,
         },
-    )(input)
+    )
+    .parse(input)
 }
 
 impl FromStr for ModeVersion {


### PR DESCRIPTION
* Add `request_filter` feature to the `game_api` crate, enabled by default
* Add environment variable for the related Discord webhook
* Add the request filter middleware, which is included in the compilation
  only with the `request_filter` feature
* Upgrade `nom` crate version from `7.1.3` to `8.0.0`

Closes #38.