### PR TITLE
Make event populate command transactional

### DIFF
--- a/game_api/src/utils.rs
+++ b/game_api/src/utils.rs
@@ -1,12 +1,11 @@
 use std::{
     convert::Infallible,
-    future::{ready, Ready},
+    future::{Ready, ready},
     ops::{Deref, DerefMut},
 };
 
-use actix_web::{dev::Payload, FromRequest, HttpRequest, HttpResponse};
-use rand::Rng;
-use records_lib::{models, Database};
+use actix_web::{FromRequest, HttpRequest, HttpResponse, dev::Payload};
+use records_lib::{Database, models};
 use serde::Serialize;
 
 use crate::{RecordsResult, RecordsResultExt};
@@ -24,16 +23,6 @@ pub fn any_repeated<T: PartialEq>(slice: &[T]) -> bool {
         }
     }
     false
-}
-
-/// Returns a randomly-generated token with the `len` length. It contains alphanumeric characters.
-#[allow(dead_code)]
-pub fn generate_token(len: usize) -> String {
-    rand::thread_rng()
-        .sample_iter(rand::distributions::Alphanumeric)
-        .map(char::from)
-        .take(len)
-        .collect()
 }
 
 #[derive(Serialize, sqlx::FromRow)]

--- a/records_lib/Cargo.toml
+++ b/records_lib/Cargo.toml
@@ -21,6 +21,7 @@ futures = { workspace = true }
 tokio = { workspace = true }
 itertools = { workspace = true }
 nom = { workspace = true }
+rand = { workspace = true }
 
 [features]
 default = []

--- a/records_lib/src/lib.rs
+++ b/records_lib/src/lib.rs
@@ -40,6 +40,7 @@ use std::future::Future;
 pub use env::*;
 pub use modeversion::*;
 pub use mptypes::*;
+use rand::Rng as _;
 
 /// Asserts that the type of the provided future is Send, and returns an opaque type from it.
 ///
@@ -51,6 +52,15 @@ where
     T: Future<Output = R> + Send,
 {
     t
+}
+
+/// Returns a randomly-generated string with the `len` length. It contains alphanumeric characters.
+pub fn gen_random_str(len: usize) -> String {
+    rand::thread_rng()
+        .sample_iter(rand::distributions::Alphanumeric)
+        .map(char::from)
+        .take(len)
+        .collect()
 }
 
 /// Represents a connection to the API database, both MariaDB and Redis.

--- a/records_lib/src/redis_key.rs
+++ b/records_lib/src/redis_key.rs
@@ -39,6 +39,8 @@ const V3_MAPPACK_LB_RANKS: &str = "ranks";
 const V3_MAPPACK_MAP_KEY_PREFIX: &str = "map";
 const V3_MAPPACK_MAP_LAST_RANK: &str = "last_rank";
 
+const V3_CACHED: &str = "cached";
+
 macro_rules! create_key {
     (
         $(#[$($attr:tt)*])*
@@ -82,6 +84,16 @@ macro_rules! create_key {
             }
         }
     }
+}
+
+create_key! {
+    ///
+    /// The cached key is a key that was copied from another.
+    struct CachedKey = cached_key {
+        /// The cached key name.
+        key_name: String,
+    }
+    |self, f| write!(f, "{V3_KEY_PREFIX}:{V3_CACHED}:{}", self.key_name)
 }
 
 create_key! {


### PR DESCRIPTION
This PR makes the admin command used to populate events with maps transactional. This means that if anything fails, it's able to recover and restore the old content.