### PR TITLE
feat: Return the texts placement of events

### DIFF
--- a/crates/game_api/src/http/event.rs
+++ b/crates/game_api/src/http/event.rs
@@ -7,8 +7,8 @@ use actix_web::{
 use futures::TryStreamExt;
 use itertools::Itertools;
 use records_lib::{
-    Database, DatabaseConnection, MySqlConnection, NullableInteger, NullableText, RedisConnection,
-    acquire,
+    Database, DatabaseConnection, MySqlConnection, NullableInteger, NullableReal, NullableText,
+    RedisConnection, acquire,
     context::{
         Context, Ctx as _, HasEditionId, HasEventId, HasEventIds, HasMap, HasPlayerLogin,
         ReadWrite, Transactional,
@@ -144,6 +144,87 @@ impl From<Vec<Map>> for Category {
     }
 }
 
+#[derive(Serialize)]
+struct EventEditionInGameParams {
+    titles_pos: NullableText,
+    lb_link_pos: NullableText,
+    authors_pos: NullableText,
+    put_subtitle_on_newline: bool,
+    titles_pos_x: NullableReal,
+    titles_pos_y: NullableReal,
+    lb_link_pos_x: NullableReal,
+    lb_link_pos_y: NullableReal,
+    authors_pos_x: NullableReal,
+    authors_pos_y: NullableReal,
+}
+
+fn pos_to_mp_pos(
+    pos: Option<models::InGamePosition>,
+    pos_x: Option<f64>,
+    pos_y: Option<f64>,
+) -> NullableText {
+    match pos {
+        None if pos_x.is_none() && pos_y.is_none() => {
+            Some(records_lib::env().ingame_default_titles_pos)
+        }
+        Some(_) if pos_x.is_some() || pos_y.is_some() => None,
+        other => other,
+    }
+    .map(|p| p.to_char().to_string())
+    .into()
+}
+
+impl From<models::InGameEventEditionParams> for EventEditionInGameParams {
+    fn from(value: models::InGameEventEditionParams) -> Self {
+        Self {
+            titles_pos: pos_to_mp_pos(value.titles_pos, value.titles_pos_x, value.titles_pos_y),
+            lb_link_pos: pos_to_mp_pos(value.lb_link_pos, value.lb_link_pos_x, value.lb_link_pos_y),
+            authors_pos: pos_to_mp_pos(value.authors_pos, value.authors_pos_x, value.authors_pos_y),
+            put_subtitle_on_newline: value
+                .put_subtitle_on_newline
+                .unwrap_or_else(|| records_lib::env().ingame_default_subtitle_on_newline),
+            titles_pos_x: value.titles_pos_x.into(),
+            titles_pos_y: value.titles_pos_y.into(),
+            lb_link_pos_x: value.lb_link_pos_x.into(),
+            lb_link_pos_y: value.lb_link_pos_y.into(),
+            authors_pos_x: value.authors_pos_x.into(),
+            authors_pos_y: value.authors_pos_y.into(),
+        }
+    }
+}
+
+impl Default for EventEditionInGameParams {
+    fn default() -> Self {
+        Self {
+            titles_pos: NullableText(Some(
+                records_lib::env()
+                    .ingame_default_titles_pos
+                    .to_char()
+                    .to_string(),
+            )),
+            lb_link_pos: NullableText(Some(
+                records_lib::env()
+                    .ingame_default_lb_link_pos
+                    .to_char()
+                    .to_string(),
+            )),
+            authors_pos: NullableText(Some(
+                records_lib::env()
+                    .ingame_default_authors_pos
+                    .to_char()
+                    .to_string(),
+            )),
+            put_subtitle_on_newline: records_lib::env().ingame_default_subtitle_on_newline,
+            titles_pos_x: NullableReal(None),
+            titles_pos_y: NullableReal(None),
+            lb_link_pos_x: NullableReal(None),
+            lb_link_pos_y: NullableReal(None),
+            authors_pos_x: NullableReal(None),
+            authors_pos_y: NullableReal(None),
+        }
+    }
+}
+
 /// An event edition from the point of view of the Obstacle gamemode.
 #[derive(Serialize)]
 struct EventHandleEditionResponse {
@@ -164,6 +245,7 @@ struct EventHandleEditionResponse {
     ///
     /// It is `None` if the edition never ends.
     end_date: NullableInteger,
+    ingame_params: EventEditionInGameParams,
     /// The URL to the banner image of the edition, used in the Titlepack menu.
     banner_img_url: String,
     /// The URL to the small banner image of the edition, used in game in the Campaign mode.
@@ -441,6 +523,14 @@ async fn edition(
         });
     }
 
+    let ingame_params = edition
+        .get_ingame_params(&mut mysql_conn)
+        .await
+        .with_api_err()
+        .fit(req_id)?
+        .map(EventEditionInGameParams::from)
+        .unwrap_or_default();
+
     let res = EventHandleEditionResponse {
         expired: edition.has_expired(),
         end_date: edition
@@ -457,6 +547,7 @@ async fn edition(
         name: edition.name,
         subtitle: edition.subtitle.unwrap_or_default(),
         start_date: edition.start_date.and_utc().timestamp() as _,
+        ingame_params,
         banner_img_url: edition.banner_img_url.unwrap_or_default(),
         banner2_img_url: edition.banner2_img_url.unwrap_or_default(),
         mx_id: edition.mx_id.map(|id| id as _).into(),

--- a/crates/game_api/src/http/event.rs
+++ b/crates/game_api/src/http/event.rs
@@ -158,14 +158,18 @@ struct EventEditionInGameParams {
     authors_pos_y: NullableReal,
 }
 
-fn pos_to_mp_pos(
-    pos: Option<models::InGamePosition>,
+/// Converts the given "raw" alignment retrieved from the DB, into the alignment that will received
+/// by the Titlepack.
+///
+/// If X or Y positions are precised, then they're used instead of the given alignment.
+fn db_align_to_mp_align(
+    alignment: Option<models::InGameAlignment>,
     pos_x: Option<f64>,
     pos_y: Option<f64>,
 ) -> NullableText {
-    match pos {
+    match alignment {
         None if pos_x.is_none() && pos_y.is_none() => {
-            Some(records_lib::env().ingame_default_titles_pos)
+            Some(records_lib::env().ingame_default_titles_align)
         }
         Some(_) if pos_x.is_some() || pos_y.is_some() => None,
         other => other,
@@ -177,9 +181,21 @@ fn pos_to_mp_pos(
 impl From<models::InGameEventEditionParams> for EventEditionInGameParams {
     fn from(value: models::InGameEventEditionParams) -> Self {
         Self {
-            titles_pos: pos_to_mp_pos(value.titles_pos, value.titles_pos_x, value.titles_pos_y),
-            lb_link_pos: pos_to_mp_pos(value.lb_link_pos, value.lb_link_pos_x, value.lb_link_pos_y),
-            authors_pos: pos_to_mp_pos(value.authors_pos, value.authors_pos_x, value.authors_pos_y),
+            titles_pos: db_align_to_mp_align(
+                value.titles_align,
+                value.titles_pos_x,
+                value.titles_pos_y,
+            ),
+            lb_link_pos: db_align_to_mp_align(
+                value.lb_link_align,
+                value.lb_link_pos_x,
+                value.lb_link_pos_y,
+            ),
+            authors_pos: db_align_to_mp_align(
+                value.authors_align,
+                value.authors_pos_x,
+                value.authors_pos_y,
+            ),
             put_subtitle_on_newline: value
                 .put_subtitle_on_newline
                 .unwrap_or_else(|| records_lib::env().ingame_default_subtitle_on_newline),
@@ -198,19 +214,19 @@ impl Default for EventEditionInGameParams {
         Self {
             titles_pos: NullableText(Some(
                 records_lib::env()
-                    .ingame_default_titles_pos
+                    .ingame_default_titles_align
                     .to_char()
                     .to_string(),
             )),
             lb_link_pos: NullableText(Some(
                 records_lib::env()
-                    .ingame_default_lb_link_pos
+                    .ingame_default_lb_link_align
                     .to_char()
                     .to_string(),
             )),
             authors_pos: NullableText(Some(
                 records_lib::env()
-                    .ingame_default_authors_pos
+                    .ingame_default_authors_align
                     .to_char()
                     .to_string(),
             )),

--- a/crates/game_api/src/http/event.rs
+++ b/crates/game_api/src/http/event.rs
@@ -146,9 +146,9 @@ impl From<Vec<Map>> for Category {
 
 #[derive(Serialize)]
 struct EventEditionInGameParams {
-    titles_pos: NullableText,
-    lb_link_pos: NullableText,
-    authors_pos: NullableText,
+    titles_align: NullableText,
+    lb_link_align: NullableText,
+    authors_align: NullableText,
     put_subtitle_on_newline: bool,
     titles_pos_x: NullableReal,
     titles_pos_y: NullableReal,
@@ -181,17 +181,17 @@ fn db_align_to_mp_align(
 impl From<models::InGameEventEditionParams> for EventEditionInGameParams {
     fn from(value: models::InGameEventEditionParams) -> Self {
         Self {
-            titles_pos: db_align_to_mp_align(
+            titles_align: db_align_to_mp_align(
                 value.titles_align,
                 value.titles_pos_x,
                 value.titles_pos_y,
             ),
-            lb_link_pos: db_align_to_mp_align(
+            lb_link_align: db_align_to_mp_align(
                 value.lb_link_align,
                 value.lb_link_pos_x,
                 value.lb_link_pos_y,
             ),
-            authors_pos: db_align_to_mp_align(
+            authors_align: db_align_to_mp_align(
                 value.authors_align,
                 value.authors_pos_x,
                 value.authors_pos_y,
@@ -212,19 +212,19 @@ impl From<models::InGameEventEditionParams> for EventEditionInGameParams {
 impl Default for EventEditionInGameParams {
     fn default() -> Self {
         Self {
-            titles_pos: NullableText(Some(
+            titles_align: NullableText(Some(
                 records_lib::env()
                     .ingame_default_titles_align
                     .to_char()
                     .to_string(),
             )),
-            lb_link_pos: NullableText(Some(
+            lb_link_align: NullableText(Some(
                 records_lib::env()
                     .ingame_default_lb_link_align
                     .to_char()
                     .to_string(),
             )),
-            authors_pos: NullableText(Some(
+            authors_align: NullableText(Some(
                 records_lib::env()
                     .ingame_default_authors_align
                     .to_char()

--- a/crates/records_lib/src/env.rs
+++ b/crates/records_lib/src/env.rs
@@ -54,9 +54,9 @@ const DEFAULT_MAPPACK_TTL: i64 = 604_800;
 
 const DEFAULT_INGAME_SUBTITLE_ON_NEWLINE: bool = false;
 
-const DEFAULT_INGAME_TITLES_POS: models::InGamePosition = models::InGamePosition::Left;
-const DEFAULT_INGAME_LB_LINK_POS: models::InGamePosition = models::InGamePosition::Left;
-const DEFAULT_INGAME_AUTHORS_POS: models::InGamePosition = models::InGamePosition::Right;
+const DEFAULT_INGAME_TITLES_ALIGN: models::InGameAlignment = models::InGameAlignment::Left;
+const DEFAULT_INGAME_LB_LINK_ALIGN: models::InGameAlignment = models::InGameAlignment::Left;
+const DEFAULT_INGAME_AUTHORS_ALIGN: models::InGameAlignment = models::InGameAlignment::Right;
 
 const DEFAULT_INGAME_TITLES_POS_X: f64 = 181.;
 const DEFAULT_INGAME_TITLES_POS_Y: f64 = -29.5;
@@ -79,34 +79,34 @@ pub LibEnv:
         default: DEFAULT_MAPPACK_TTL,
     },
 
-    /// The default position of the titles of an event edition in the Titlepack menu.
-    ingame_default_titles_pos: {
-        id: InGameDefaultTitlesPos(models::InGamePosition),
+    /// The default alignment of the titles of an event edition in the Titlepack menu.
+    ingame_default_titles_align: {
+        id: InGameDefaultTitlesAlign(models::InGameAlignment),
         kind: parse,
-        var: "RECORDS_API_INGAME_DEFAULT_TITLES_POS",
-        desc: "The default position (either L for left or R for right) of the titles of \
+        var: "RECORDS_API_INGAME_DEFAULT_TITLES_ALIGN",
+        desc: "The default alignment (either L for left or R for right) of the titles of \
             an event edition in the Titlepack menu",
-        default: DEFAULT_INGAME_TITLES_POS,
+        default: DEFAULT_INGAME_TITLES_ALIGN,
     },
 
-    /// The default position of an event edition title in the Titlepack menu.
-    ingame_default_lb_link_pos: {
-        id: InGameDefaultLbLinkPos(models::InGamePosition),
+    /// The default alignment of an event edition title in the Titlepack menu.
+    ingame_default_lb_link_align: {
+        id: InGameDefaultLbLinkAlign(models::InGameAlignment),
         kind: parse,
-        var: "RECORDS_API_INGAME_DEFAULT_LB_LINK_POS",
-        desc: "The default position (either L for left or R for right) of the leaderboards link of \
+        var: "RECORDS_API_INGAME_DEFAULT_LB_LINK_ALIGN",
+        desc: "The default alignment (either L for left or R for right) of the leaderboards link of \
             an event edition in the Titlepack menu",
-        default: DEFAULT_INGAME_LB_LINK_POS,
+        default: DEFAULT_INGAME_LB_LINK_ALIGN,
     },
 
-    /// The default position of an event edition title in the Titlepack menu.
-    ingame_default_authors_pos: {
-        id: InGameDefaultAuthorsPos(models::InGamePosition),
+    /// The default alignment of an event edition title in the Titlepack menu.
+    ingame_default_authors_align: {
+        id: InGameDefaultAuthorsAlign(models::InGameAlignment),
         kind: parse,
-        var: "RECORDS_API_INGAME_DEFAULT_AUTHORS_POS",
-        desc: "The default position (either L for left or R for right) of the author list of \
+        var: "RECORDS_API_INGAME_DEFAULT_AUTHORS_ALIGN",
+        desc: "The default alignment (either L for left or R for right) of the author list of \
             an event edition in the Titlepack menu",
-        default: DEFAULT_INGAME_AUTHORS_POS,
+        default: DEFAULT_INGAME_AUTHORS_ALIGN,
     },
 
     /// The default position in X axis of the titles of an event edition in the Titlepack menu.

--- a/crates/records_lib/src/env.rs
+++ b/crates/records_lib/src/env.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use deadpool_redis::Runtime;
 use once_cell::sync::OnceCell;
 
-use crate::{MySqlPool, RedisPool};
+use crate::{MySqlPool, RedisPool, models};
 
 mkenv::make_env! {
 /// The environment used to set up a connection to the MySQL/MariaDB database.
@@ -50,6 +50,23 @@ mkenv::make_env! {
 
 const DEFAULT_MAPPACK_TTL: i64 = 604_800;
 
+// In game default parameter values
+
+const DEFAULT_INGAME_SUBTITLE_ON_NEWLINE: bool = false;
+
+const DEFAULT_INGAME_TITLES_POS: models::InGamePosition = models::InGamePosition::Left;
+const DEFAULT_INGAME_LB_LINK_POS: models::InGamePosition = models::InGamePosition::Left;
+const DEFAULT_INGAME_AUTHORS_POS: models::InGamePosition = models::InGamePosition::Right;
+
+const DEFAULT_INGAME_TITLES_POS_X: f64 = 181.;
+const DEFAULT_INGAME_TITLES_POS_Y: f64 = -29.5;
+
+const DEFAULT_INGAME_LB_LINK_POS_X: f64 = 181.;
+const DEFAULT_INGAME_LB_LINK_POS_Y: f64 = -29.5;
+
+const DEFAULT_INGAME_AUTHORS_POS_X: f64 = 181.;
+const DEFAULT_INGAME_AUTHORS_POS_Y: f64 = -29.5;
+
 mkenv::make_env! {
 /// The environment used by this crate.
 pub LibEnv:
@@ -60,7 +77,108 @@ pub LibEnv:
         var: "RECORDS_API_MAPPACK_TTL",
         desc: "The TTL (time-to-live) of the mappacks stored in Redis",
         default: DEFAULT_MAPPACK_TTL,
-    }
+    },
+
+    /// The default position of the titles of an event edition in the Titlepack menu.
+    ingame_default_titles_pos: {
+        id: InGameDefaultTitlesPos(models::InGamePosition),
+        kind: parse,
+        var: "RECORDS_API_INGAME_DEFAULT_TITLES_POS",
+        desc: "The default position (either L for left or R for right) of the titles of \
+            an event edition in the Titlepack menu",
+        default: DEFAULT_INGAME_TITLES_POS,
+    },
+
+    /// The default position of an event edition title in the Titlepack menu.
+    ingame_default_lb_link_pos: {
+        id: InGameDefaultLbLinkPos(models::InGamePosition),
+        kind: parse,
+        var: "RECORDS_API_INGAME_DEFAULT_LB_LINK_POS",
+        desc: "The default position (either L for left or R for right) of the leaderboards link of \
+            an event edition in the Titlepack menu",
+        default: DEFAULT_INGAME_LB_LINK_POS,
+    },
+
+    /// The default position of an event edition title in the Titlepack menu.
+    ingame_default_authors_pos: {
+        id: InGameDefaultAuthorsPos(models::InGamePosition),
+        kind: parse,
+        var: "RECORDS_API_INGAME_DEFAULT_AUTHORS_POS",
+        desc: "The default position (either L for left or R for right) of the author list of \
+            an event edition in the Titlepack menu",
+        default: DEFAULT_INGAME_AUTHORS_POS,
+    },
+
+    /// The default position in X axis of the titles of an event edition in the Titlepack menu.
+    ingame_default_titles_pos_x: {
+        id: InGameDefaultTitlesPosX(f64),
+        kind: parse,
+        var: "RECORDS_API_INGAME_DEFAULT_TITLES_POS_X",
+        desc: "The default position in X axis of the titles of an event edition in \
+            the Titlepack menu (double)",
+        default: DEFAULT_INGAME_TITLES_POS_X,
+    },
+
+    /// The default position in Y axis of the titles of an event edition in the Titlepack menu.
+    ingame_default_titles_pos_y: {
+        id: InGameDefaultTitlesPosY(f64),
+        kind: parse,
+        var: "RECORDS_API_INGAME_DEFAULT_TITLES_POS_Y",
+        desc: "The default position in Y axis of the titles of an event edition in \
+            the Titlepack menu (double)",
+        default: DEFAULT_INGAME_TITLES_POS_Y,
+    },
+
+    /// The default value of the boolean related to either to put the subtitle of an event edition
+    /// on a new line or not, in the Titlepack menu.
+    ingame_default_subtitle_on_newline: {
+        id: InGameDefaultSubtitleOnNewLine(bool),
+        kind: parse,
+        var: "RECORDS_API_INGAME_DEFAULT_SUBTITLE_ON_NEWLINE",
+        desc: "The default value of the boolean related to either to put the subtitle of an \
+            event edition on a new line or not in the Titlepack menu (boolean)",
+        default: DEFAULT_INGAME_SUBTITLE_ON_NEWLINE,
+    },
+
+    /// The default position in X axis of the leaderboards link of an event edition in the Titlepack menu.
+    ingame_default_lb_link_pos_x: {
+        id: InGameDefaultLbLinkPosX(f64),
+        kind: parse,
+        var: "RECORDS_API_INGAME_DEFAULT_LB_LINK_POS_X",
+        desc: "The default position in X axis of the leaderboards link of an event edition in \
+            the Titlepack menu (double)",
+        default: DEFAULT_INGAME_LB_LINK_POS_X,
+    },
+
+    /// The default position in Y axis of the leaderboards link of an event edition in the Titlepack menu.
+    ingame_default_lb_link_pos_y: {
+        id: InGameDefaultLbLinkPosY(f64),
+        kind: parse,
+        var: "RECORDS_API_INGAME_DEFAULT_LB_LINK_POS_Y",
+        desc: "The default position in Y axis of the leaderboards link of an event edition in \
+            the Titlepack menu (double)",
+        default: DEFAULT_INGAME_LB_LINK_POS_Y,
+    },
+
+    /// The default position in X axis of the author list of an event edition in the Titlepack menu.
+    ingame_default_authors_pos_x: {
+        id: InGameDefaultAuthorsPosX(f64),
+        kind: parse,
+        var: "RECORDS_API_INGAME_DEFAULT_AUTHORS_POS_X",
+        desc: "The default position in X axis of the author list of an event edition in \
+            the Titlepack menu (double)",
+        default: DEFAULT_INGAME_AUTHORS_POS_X,
+    },
+
+    /// The default position in Y axis of the author list of an event edition in the Titlepack menu.
+    ingame_default_authors_pos_y: {
+        id: InGameDefaultAuthorsPosY(f64),
+        kind: parse,
+        var: "RECORDS_API_INGAME_DEFAULT_AUTHORS_POS_Y",
+        desc: "The default position in Y axis of the author list of an event edition in \
+            the Titlepack menu (double)",
+        default: DEFAULT_INGAME_AUTHORS_POS_Y,
+    },
 }
 
 static ENV: OnceCell<LibEnv> = OnceCell::new();

--- a/crates/records_lib/src/models.rs
+++ b/crates/records_lib/src/models.rs
@@ -5,11 +5,13 @@
 //! the types correspond to the raw tables in the database. This means that relations between models
 //! are only represented by a foreign key like an ID.
 
-use std::fmt;
+use std::{fmt, str::FromStr};
 
 use async_graphql::{Enum, SimpleObject};
 use serde::Serialize;
 use sqlx::{FromRow, Row, mysql::MySqlRow};
+
+use crate::error::RecordsResult;
 
 /// A player in the database.
 #[derive(Serialize, FromRow, Clone, Debug)]
@@ -286,6 +288,122 @@ pub struct EventCategory {
     pub hex_color: Option<String>,
 }
 
+/// The position of an item in the Titlepack menu.
+#[derive(Serialize, Clone, Copy, Debug)]
+#[repr(u8)]
+#[serde(into = "char")]
+pub enum InGamePosition {
+    /// The item is positioned on left.
+    Left = b'L',
+    /// The item is positioned on right.
+    Right = b'R',
+}
+
+impl From<InGamePosition> for char {
+    fn from(pos: InGamePosition) -> Self {
+        pos.to_char()
+    }
+}
+
+impl InGamePosition {
+    fn try_from_char(c: char) -> Result<Self, sqlx::error::BoxDynError> {
+        match c {
+            'L' => Ok(Self::Left),
+            'R' => Ok(Self::Right),
+            c => Err(format!("invalid character: '{c}', expected 'L' or 'R'").into()),
+        }
+    }
+
+    /// Converts an [`InGamePosition`] into a character (either 'L' or 'R').
+    pub fn to_char(self) -> char {
+        self as u8 as char
+    }
+}
+
+impl FromStr for InGamePosition {
+    type Err = sqlx::error::BoxDynError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.chars().next() {
+            Some(c) if s.len() == 1 => Self::try_from_char(c),
+            _ => Err("expected one character, either 'L' or 'R'"
+                .to_owned()
+                .into()),
+        }
+    }
+}
+
+impl<'a> sqlx::Decode<'a, sqlx::MySql> for InGamePosition {
+    fn decode(
+        value: <sqlx::MySql as sqlx::Database>::ValueRef<'a>,
+    ) -> Result<Self, sqlx::error::BoxDynError> {
+        let s = <&'a str as sqlx::Decode<'a, sqlx::MySql>>::decode(value)?;
+        Self::from_str(s)
+    }
+}
+
+impl sqlx::Type<sqlx::MySql> for InGamePosition {
+    #[inline(always)]
+    fn type_info() -> <sqlx::MySql as sqlx::Database>::TypeInfo {
+        <str as sqlx::Type<sqlx::MySql>>::type_info()
+    }
+
+    #[inline(always)]
+    fn compatible(ty: &<sqlx::MySql as sqlx::Database>::TypeInfo) -> bool {
+        <str as sqlx::Type<sqlx::MySql>>::compatible(ty)
+    }
+}
+
+/// Contains some additional parameters related to an [event edition](EventEdition).
+#[derive(Serialize, FromRow, Clone, Debug)]
+pub struct InGameEventEditionParams {
+    /// The ID of the additional parameters. This is just used as a foreign key by the event edition.
+    pub id: i32,
+
+    /// The boolean value of either to put the subtitle on a new line or not in the Titlepack menu.
+    ///
+    /// The default value is defined [here](crate::LibEnv::ingame_default_subtitle_on_newline).
+    pub put_subtitle_on_newline: Option<bool>,
+
+    /// The position of the event edition titles.
+    ///
+    /// The default value is defined [here](crate::LibEnv::ingame_default_titles_pos).
+    pub titles_pos: Option<InGamePosition>,
+    /// The position of the leaderboards link of the event edition.
+    ///
+    /// The default value is defined [here](crate::LibEnv::ingame_default_lb_link_pos).
+    pub lb_link_pos: Option<InGamePosition>,
+    /// The position of the author list of the event edition.
+    ///
+    /// The default value is defined [here](crate::LibEnv::ingame_default_authors_pos).
+    pub authors_pos: Option<InGamePosition>,
+
+    /// The X position of the event edition titles in the Titlepack menu.
+    ///
+    /// The default value is defined [here](crate::LibEnv::ingame_default_titles_pos_x).
+    pub titles_pos_x: Option<f64>,
+    /// The Y position of the event edition titles in the Titlepack menu.
+    ///
+    /// The default value is defined [here](crate::LibEnv::ingame_default_titles_pos_y).
+    pub titles_pos_y: Option<f64>,
+    /// The X position of the leaderboards link of the event edition in the Titlepack menu.
+    ///
+    /// The default value is defined [here](crate::LibEnv::ingame_default_lb_link_pos_x).
+    pub lb_link_pos_x: Option<f64>,
+    /// The Y position of the leaderboards link of the event edition in the Titlepack menu.
+    ///
+    /// The default value is defined [here](crate::LibEnv::ingame_default_lb_link_pos_y).
+    pub lb_link_pos_y: Option<f64>,
+    /// The X position of the author list of the event edition in the Titlepack menu.
+    ///
+    /// The default value is defined [here](crate::LibEnv::ingame_default_authors_pos_x).
+    pub authors_pos_x: Option<f64>,
+    /// The Y position of the author list of the event edition in the Titlepack menu.
+    ///
+    /// The default value is defined [here](crate::LibEnv::ingame_default_authors_pos_y).
+    pub authors_pos_y: Option<f64>,
+}
+
 /// An event edition in the database.
 #[derive(Serialize, FromRow, Clone, Debug)]
 pub struct EventEdition {
@@ -324,6 +442,10 @@ pub struct EventEdition {
     /// This is used by the `global_records` view to retrieve the records of the events that don't
     /// have original maps.
     pub non_original_maps: bool,
+    /// The foreign key to the in-game parameters of this event edition.
+    ///
+    /// The related model is [`InGameEventEditionParams`].
+    pub ingame_params_id: Option<i32>,
 }
 
 impl EventEdition {
@@ -346,6 +468,23 @@ impl EventEdition {
     /// Returns whether the edition has expired or not.
     pub fn has_expired(&self) -> bool {
         self.expires_in().filter(|n| *n < 0).is_some()
+    }
+
+    /// Returns the additional in-game parameters of this event edition.
+    pub async fn get_ingame_params(
+        &self,
+        mysql_conn: &mut sqlx::MySqlConnection,
+    ) -> RecordsResult<Option<InGameEventEditionParams>> {
+        let Some(id) = self.ingame_params_id else {
+            return Ok(None);
+        };
+
+        let params = sqlx::query_as("select * from in_game_event_edition_params where id = ?")
+            .bind(id)
+            .fetch_optional(mysql_conn)
+            .await?;
+
+        Ok(params)
     }
 }
 

--- a/crates/records_lib/src/models.rs
+++ b/crates/records_lib/src/models.rs
@@ -288,24 +288,24 @@ pub struct EventCategory {
     pub hex_color: Option<String>,
 }
 
-/// The position of an item in the Titlepack menu.
+/// The alignment of an item in the Titlepack menu.
 #[derive(Serialize, Clone, Copy, Debug)]
 #[repr(u8)]
 #[serde(into = "char")]
-pub enum InGamePosition {
+pub enum InGameAlignment {
     /// The item is positioned on left.
     Left = b'L',
     /// The item is positioned on right.
     Right = b'R',
 }
 
-impl From<InGamePosition> for char {
-    fn from(pos: InGamePosition) -> Self {
+impl From<InGameAlignment> for char {
+    fn from(pos: InGameAlignment) -> Self {
         pos.to_char()
     }
 }
 
-impl InGamePosition {
+impl InGameAlignment {
     fn try_from_char(c: char) -> Result<Self, sqlx::error::BoxDynError> {
         match c {
             'L' => Ok(Self::Left),
@@ -314,13 +314,13 @@ impl InGamePosition {
         }
     }
 
-    /// Converts an [`InGamePosition`] into a character (either 'L' or 'R').
+    /// Converts an [`InGameAlignment`] into a character (either 'L' or 'R').
     pub fn to_char(self) -> char {
         self as u8 as char
     }
 }
 
-impl FromStr for InGamePosition {
+impl FromStr for InGameAlignment {
     type Err = sqlx::error::BoxDynError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -333,7 +333,7 @@ impl FromStr for InGamePosition {
     }
 }
 
-impl<'a> sqlx::Decode<'a, sqlx::MySql> for InGamePosition {
+impl<'a> sqlx::Decode<'a, sqlx::MySql> for InGameAlignment {
     fn decode(
         value: <sqlx::MySql as sqlx::Database>::ValueRef<'a>,
     ) -> Result<Self, sqlx::error::BoxDynError> {
@@ -342,7 +342,7 @@ impl<'a> sqlx::Decode<'a, sqlx::MySql> for InGamePosition {
     }
 }
 
-impl sqlx::Type<sqlx::MySql> for InGamePosition {
+impl sqlx::Type<sqlx::MySql> for InGameAlignment {
     #[inline(always)]
     fn type_info() -> <sqlx::MySql as sqlx::Database>::TypeInfo {
         <str as sqlx::Type<sqlx::MySql>>::type_info()
@@ -365,18 +365,18 @@ pub struct InGameEventEditionParams {
     /// The default value is defined [here](crate::LibEnv::ingame_default_subtitle_on_newline).
     pub put_subtitle_on_newline: Option<bool>,
 
-    /// The position of the event edition titles.
+    /// The alignment of the event edition titles.
     ///
-    /// The default value is defined [here](crate::LibEnv::ingame_default_titles_pos).
-    pub titles_pos: Option<InGamePosition>,
-    /// The position of the leaderboards link of the event edition.
+    /// The default value is defined [here](crate::LibEnv::ingame_default_titles_align).
+    pub titles_align: Option<InGameAlignment>,
+    /// The alignment of the leaderboards link of the event edition.
     ///
-    /// The default value is defined [here](crate::LibEnv::ingame_default_lb_link_pos).
-    pub lb_link_pos: Option<InGamePosition>,
-    /// The position of the author list of the event edition.
+    /// The default value is defined [here](crate::LibEnv::ingame_default_lb_link_align).
+    pub lb_link_align: Option<InGameAlignment>,
+    /// The alignment of the author list of the event edition.
     ///
-    /// The default value is defined [here](crate::LibEnv::ingame_default_authors_pos).
-    pub authors_pos: Option<InGamePosition>,
+    /// The default value is defined [here](crate::LibEnv::ingame_default_authors_align).
+    pub authors_align: Option<InGameAlignment>,
 
     /// The X position of the event edition titles in the Titlepack menu.
     ///

--- a/crates/records_lib/src/modeversion.rs
+++ b/crates/records_lib/src/modeversion.rs
@@ -95,10 +95,18 @@ fn parse_u8(input: &str) -> nom::IResult<&str, u8> {
     .parse(input)
 }
 
+fn parse_patch_or_0(input: &str) -> nom::IResult<&str, u8> {
+    let out = (tag("."), parse_u8)
+        .parse(input)
+        .map(|(input, (_, patch))| (input, patch))
+        .unwrap_or((input, 0));
+    Ok(out)
+}
+
 fn parse_mode_version(input: &str) -> nom::IResult<&str, ModeVersion> {
     map(
-        (parse_u8, tag("."), parse_u8, tag("."), parse_u8),
-        |(major, _, minor, _, patch)| ModeVersion::new(major, minor, patch),
+        (parse_u8, tag("."), parse_u8, parse_patch_or_0),
+        |(major, _, minor, patch)| ModeVersion::new(major, minor, patch),
     )
     .parse(input)
 }

--- a/migrations/migrations/20250409204305_event_edition_params_table.down.sql
+++ b/migrations/migrations/20250409204305_event_edition_params_table.down.sql
@@ -1,0 +1,7 @@
+alter table
+  event_edition drop foreign key event_edition___fk_ingame_params;
+
+alter table
+  event_edition drop column ingame_params_id;
+
+drop table in_game_event_edition_params;

--- a/migrations/migrations/20250409204305_event_edition_params_table.up.sql
+++ b/migrations/migrations/20250409204305_event_edition_params_table.up.sql
@@ -1,0 +1,33 @@
+create table in_game_event_edition_params (
+  id int auto_increment primary key,
+  put_subtitle_on_newline boolean default false null,
+  titles_pos char default 'L' null,
+  lb_link_pos char default 'L' null,
+  authors_pos char default 'R' null,
+  titles_pos_x double null,
+  titles_pos_y double null,
+  lb_link_pos_x double null,
+  lb_link_pos_y double null,
+  authors_pos_x double null,
+  authors_pos_y double null,
+  constraint position_types check (
+    in_game_event_edition_params.titles_pos is null
+    or in_game_event_edition_params.titles_pos in ('L', 'R')
+    and in_game_event_edition_params.lb_link_pos is null
+    or in_game_event_edition_params.lb_link_pos in ('L', 'R')
+    and in_game_event_edition_params.authors_pos is null
+    or in_game_event_edition_params.authors_pos in ('L', 'R')
+  )
+);
+
+alter table
+  event_edition
+add
+  ingame_params_id int null;
+
+alter table
+  event_edition
+add
+  constraint event_edition___fk_ingame_params foreign key (ingame_params_id) references in_game_event_edition_params (id) on delete
+set
+  null;

--- a/migrations/migrations/20250410182342_rename_ingame_event_params_pos_to_align.down.sql
+++ b/migrations/migrations/20250410182342_rename_ingame_event_params_pos_to_align.down.sql
@@ -1,0 +1,8 @@
+alter table
+  in_game_event_edition_params change titles_align titles_pos char default 'L' null;
+
+alter table
+  in_game_event_edition_params change lb_link_align lb_link_pos char default 'L' null;
+
+alter table
+  in_game_event_edition_params change authors_align authors_pos char default 'R' null;

--- a/migrations/migrations/20250410182342_rename_ingame_event_params_pos_to_align.up.sql
+++ b/migrations/migrations/20250410182342_rename_ingame_event_params_pos_to_align.up.sql
@@ -1,0 +1,8 @@
+alter table
+  in_game_event_edition_params change titles_pos titles_align char default 'L' null;
+
+alter table
+  in_game_event_edition_params change lb_link_pos lb_link_align char default 'L' null;
+
+alter table
+  in_game_event_edition_params change authors_pos authors_align char default 'R' null;


### PR DESCRIPTION
This PR makes the `/event/<handle>/<edition>` to return additional info concerning the placement parameters of the titles of the event edition, and other stuff, for the Titlepack.

Related to https://github.com/SM-Obstacle/Titlepack/issues/21.
Closes #57.