### PR TITLE
Add "hex_color" field in event edition category

### DIFF
--- a/crates/game_api/src/http/event.rs
+++ b/crates/game_api/src/http/event.rs
@@ -131,7 +131,8 @@ struct Map {
 struct Category {
     handle: String,
     name: String,
-    banner_img_url: String,
+    banner_img_url: NullableText,
+    hex_color: NullableText,
     maps: Vec<Map>,
 }
 
@@ -557,7 +558,8 @@ async fn edition(
         categories.push(Category {
             handle: m.handle,
             name: m.name,
-            banner_img_url: m.banner_img_url.unwrap_or_default(),
+            banner_img_url: m.banner_img_url.into(),
+            hex_color: m.hex_color.into(),
             maps,
         });
     }
@@ -567,7 +569,8 @@ async fn edition(
         categories.push(Category {
             handle: cat.handle,
             name: cat.name,
-            banner_img_url: cat.banner_img_url.unwrap_or_default(),
+            banner_img_url: cat.banner_img_url.into(),
+            hex_color: cat.hex_color.into(),
             maps: Vec::new(),
         });
     }


### PR DESCRIPTION
This PR adds a `"hex_color"` field to the JSON object of an event edition category, in the endpoint of an event edition info.

Closes #73.