### PR TITLE
feat: Add availability fields for an event map

### DIFF
--- a/crates/entity/src/entities/event_edition_maps.rs
+++ b/crates/entity/src/entities/event_edition_maps.rs
@@ -44,6 +44,17 @@ pub struct Model {
     ///
     /// This is an optional URL to the map thumbnail file. By default, the file is retrieved from SMX.
     pub thumbnail_source: Option<String>,
+    /// Whether the map is available or not to play.
+    ///
+    /// Most of the time, this is true, but it might be false if the map is hidden from MX, and the
+    /// author explicitly wants it to not be playable.
+    pub is_available: bool,
+    /// Whether the map should be disabled.
+    ///
+    /// The difference with the [`is_available`](Model::is_available) field, is that the latter is
+    /// only used for UI stuff, whereas this one is a guard to avoid saving records on the map if
+    /// this flag is on.
+    pub is_disabled: bool,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/crates/game_api/src/http/event.rs
+++ b/crates/game_api/src/http/event.rs
@@ -68,6 +68,7 @@ struct MapWithCategory {
     original_map_id: Option<u32>,
     source: Option<String>,
     thumbnail_source: Option<String>,
+    is_available: bool,
 }
 
 async fn get_maps_by_edition_id<C: ConnectionTrait>(
@@ -93,6 +94,7 @@ async fn get_maps_by_edition_id<C: ConnectionTrait>(
             event_edition_maps::Column::OriginalMapId,
             event_edition_maps::Column::Source,
             event_edition_maps::Column::ThumbnailSource,
+            event_edition_maps::Column::IsAvailable,
         ])
         .into_model()
         .all(conn)
@@ -164,6 +166,7 @@ struct Map {
     original_map: OriginalMap,
     source: NullableText,
     thumbnail_source: NullableText,
+    is_available: bool,
 }
 
 #[derive(Serialize, Default)]
@@ -467,6 +470,7 @@ async fn edition(
                 original_map_id,
                 source,
                 thumbnail_source,
+                is_available,
                 ..
             } = cat_map;
 
@@ -666,6 +670,7 @@ async fn edition(
                 next_opponent: next_opponent.unwrap_or_default(),
                 source: source.into(),
                 thumbnail_source: thumbnail_source.into(),
+                is_available,
             });
         }
 

--- a/crates/migration/src/lib.rs
+++ b/crates/migration/src/lib.rs
@@ -4,6 +4,8 @@ mod m20250806_191954_create_views;
 mod m20250806_202048_populate;
 mod m20250918_132016_add_event_edition_maps_source;
 mod m20250918_135135_add_event_edition_maps_thumbnail_source;
+mod m20250918_215914_add_event_edition_maps_availability;
+mod m20250918_222203_add_event_edition_maps_disability;
 
 use sea_orm_migration::prelude::*;
 
@@ -21,6 +23,8 @@ impl MigratorTrait for Migrator {
             Box::new(m20250806_202048_populate::Migration),
             Box::new(m20250918_132016_add_event_edition_maps_source::Migration),
             Box::new(m20250918_135135_add_event_edition_maps_thumbnail_source::Migration),
+            Box::new(m20250918_215914_add_event_edition_maps_availability::Migration),
+            Box::new(m20250918_222203_add_event_edition_maps_disability::Migration),
         ]
     }
 }

--- a/crates/migration/src/m20250918_215914_add_event_edition_maps_availability.rs
+++ b/crates/migration/src/m20250918_215914_add_event_edition_maps_availability.rs
@@ -1,0 +1,40 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(EventEditionMaps::Table)
+                    .add_column(
+                        ColumnDef::new(EventEditionMaps::IsAvailable)
+                            .boolean()
+                            .default(true)
+                            .take(),
+                    )
+                    .take(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(EventEditionMaps::Table)
+                    .drop_column(EventEditionMaps::IsAvailable)
+                    .take(),
+            )
+            .await
+    }
+}
+
+#[derive(DeriveIden)]
+enum EventEditionMaps {
+    Table,
+    IsAvailable,
+}

--- a/crates/migration/src/m20250918_222203_add_event_edition_maps_disability.rs
+++ b/crates/migration/src/m20250918_222203_add_event_edition_maps_disability.rs
@@ -1,0 +1,40 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(EventEditionMaps::Table)
+                    .add_column(
+                        ColumnDef::new(EventEditionMaps::IsDisabled)
+                            .boolean()
+                            .default(false)
+                            .take(),
+                    )
+                    .take(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(EventEditionMaps::Table)
+                    .drop_column(EventEditionMaps::IsDisabled)
+                    .take(),
+            )
+            .await
+    }
+}
+
+#[derive(DeriveIden)]
+enum EventEditionMaps {
+    Table,
+    IsDisabled,
+}

--- a/crates/records_lib/src/event.rs
+++ b/crates/records_lib/src/event.rs
@@ -310,6 +310,7 @@ pub async fn get_editions_which_contain<C: ConnectionTrait + StreamTrait>(
             event_edition::Column::SaveNonEventRecord
                 .ne(0)
                 .and(event_edition::Column::IsTransparent.eq(0))
+                .and(event_edition_maps::Column::IsDisabled.eq(0))
                 .and(event_edition_maps::Column::MapId.eq(map_id)),
         )
         .select_only()
@@ -385,7 +386,8 @@ pub async fn get_map_in_edition<C: ConnectionTrait>(
                     Expr::col(("map", maps::Column::Id))
                         .equals(("original_map", maps::Column::Id))
                         .or(event_edition_maps::Column::TransitiveSave.ne(0)),
-                ),
+                )
+                .and(event_edition_maps::Column::IsDisabled.eq(0)),
         )
         .select_only()
         .expr(Expr::col(("map", Asterisk)))


### PR DESCRIPTION
* Add `"is_available"` new field for JSON response of `/event/<handle>/<edition>` service
* Add `is_available` and `is_disabled` SQL columns in respective migrations
* Check for the `is_disabled` column to be false when saving a record to an event map

Closes #80.