### PR TITLE
feat: Map medal times

### DIFF
--- a/crates/entity/src/entities/maps.rs
+++ b/crates/entity/src/entities/maps.rs
@@ -23,6 +23,15 @@ pub struct Model {
     ///
     /// This was created for future features.
     pub linked_map: Option<u32>,
+
+    /// The bronze time of the map.
+    pub bronze_time: Option<i32>,
+    /// The silver time of the map.
+    pub silver_time: Option<i32>,
+    /// The gold time of the map.
+    pub gold_time: Option<i32>,
+    /// The author time of the map.
+    pub author_time: Option<i32>,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/crates/migration/src/lib.rs
+++ b/crates/migration/src/lib.rs
@@ -6,6 +6,7 @@ mod m20250918_132016_add_event_edition_maps_source;
 mod m20250918_135135_add_event_edition_maps_thumbnail_source;
 mod m20250918_215914_add_event_edition_maps_availability;
 mod m20250918_222203_add_event_edition_maps_disability;
+mod m20251004_214656_add_maps_medal_times;
 
 use sea_orm_migration::prelude::*;
 
@@ -25,6 +26,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20250918_135135_add_event_edition_maps_thumbnail_source::Migration),
             Box::new(m20250918_215914_add_event_edition_maps_availability::Migration),
             Box::new(m20250918_222203_add_event_edition_maps_disability::Migration),
+            Box::new(m20251004_214656_add_maps_medal_times::Migration),
         ]
     }
 }

--- a/crates/migration/src/m20251004_214656_add_maps_medal_times.rs
+++ b/crates/migration/src/m20251004_214656_add_maps_medal_times.rs
@@ -1,0 +1,44 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Maps::Table)
+                    .add_column(ColumnDef::new(Maps::BronzeTime).null().integer().take())
+                    .add_column(ColumnDef::new(Maps::SilverTime).null().integer().take())
+                    .add_column(ColumnDef::new(Maps::GoldTime).null().integer().take())
+                    .add_column(ColumnDef::new(Maps::AuthorTime).null().integer().take())
+                    .take(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Maps::Table)
+                    .drop_column(Maps::BronzeTime)
+                    .drop_column(Maps::SilverTime)
+                    .drop_column(Maps::GoldTime)
+                    .drop_column(Maps::AuthorTime)
+                    .take(),
+            )
+            .await
+    }
+}
+
+#[derive(DeriveIden)]
+enum Maps {
+    Table,
+    BronzeTime,
+    SilverTime,
+    GoldTime,
+    AuthorTime,
+}


### PR DESCRIPTION
* Add medal times SQL column bound to maps table with migration
* Fill them with the `/map/insert` game API service, that updates them when available, like the `cps_number` field